### PR TITLE
make sure instance conversion always happens before accessing the object

### DIFF
--- a/lncrawl/services/crawler/utils.py
+++ b/lncrawl/services/crawler/utils.py
@@ -45,8 +45,11 @@ def __format_volume(crawler: Crawler, vol_id_map: Dict[int, int]):
 def __format_chapters(crawler: Crawler, vol_id_map: Dict[int, int]):
     crawler.chapters = [
         chap if isinstance(chap, Chapter) else Chapter(**chap)
-        for chap in sorted(crawler.chapters, key=lambda x: x.id)
+        for chap in crawler.chapters
     ]
+
+    crawler.chapters = sorted(crawler.chapters, key=lambda x: x.id)
+
     for index, item in enumerate(crawler.chapters):
         item.id = index + 1
         item.extra['crawler_version'] = getattr(crawler, 'version')


### PR DESCRIPTION
When downloading from royalroad i noticed the following issue:
```
───────────────────── Traceback (most recent call last) ──────────────────────╮
│ /app/lncrawl/commands/crawl.py:86 in crawl                                   │
│                                                                              │
│    83 │   # fetch novel details                                              │
│    84 │   with console.status('Fetching novel details...'):                  │
│    85 │   │   user = ctx.users.get_admin()                                   │
│ ❱  86 │   │   novel = ctx.crawler.fetch_novel(user.id, url, crawler=crawler) │
│    87 │   print(Panel('\n'.join(filter(None, [                               │
│    88 │   │   f'[cyan]{novel.url}[/cyan]',                                   │
│    89 │   │   f'[yellow][b]{novel.title}[/b][/yellow]',                      │
│                                                                              │
│ /app/lncrawl/services/crawler/service.py:55 in fetch_novel                   │
│                                                                              │
│    52 │   │                                                                  │
│    53 │   │   # fetch novel metadata                                         │
│    54 │   │   crawler.read_novel_info()                                      │
│ ❱  55 │   │   format_novel(crawler)                                          │
│    56 │   │                                                                  │
│    57 │   │   # save to database                                             │
│    58 │   │   with ctx.db.session() as sess:                                 │
│                                                                              │
│ /app/lncrawl/services/crawler/utils.py:70 in format_novel                    │
│                                                                              │
│    67 def format_novel(crawler: Crawler):                                    │
│    68 │   vol_id_map: Dict[int, int] = {}                                    │
│    69 │   __format_volume(crawler, vol_id_map)                               │
│ ❱  70 │   __format_chapters(crawler, vol_id_map)                             │
│    71 │   crawler.volumes = [x for x in crawler.volumes if x.chapter_count]  │
│    72 │                                                                      │
│    73 │   crawler.novel_title = __format_title(crawler.novel_title)          │
│                                                                              │
│ /app/lncrawl/services/crawler/utils.py:48 in __format_chapters               │
│                                                                              │
│    45 def __format_chapters(crawler: Crawler, vol_id_map: Dict[int, int]):   │
│    46 │   crawler.chapters = [                                               │
│    47 │   │   chap if isinstance(chap, Chapter) else Chapter(**chap)         │
│ ❱  48 │   │   for chap in sorted(crawler.chapters, key=lambda x: x.id)       │
│    49 │   ]                                                                  │
│    50 │   for index, item in enumerate(crawler.chapters):                    │
│    51 │   │   item.id = index + 1                                            │
│                                                                              │
│ /app/lncrawl/services/crawler/utils.py:48 in <lambda>                        │
│                                                                              │
│    45 def __format_chapters(crawler: Crawler, vol_id_map: Dict[int, int]):   │
│    46 │   crawler.chapters = [                                               │
│    47 │   │   chap if isinstance(chap, Chapter) else Chapter(**chap)         │
│ ❱  48 │   │   for chap in sorted(crawler.chapters, key=lambda x: x.id)       │
│    49 │   ]                                                                  │
│    50 │   for index, item in enumerate(crawler.chapters):                    │
│    51 │   │   item.id = index + 1                                            │
╰──────────────────────────────────────────────────────────────────────────────╯
AttributeError: 'dict' object has no attribute 'id'`
```
So this commit fixes the issue, while also making sure to always type cast before accessing the object.