### PR TITLE
Patch novelfire cover selector

### DIFF
--- a/sources/en/n/novelfire.py
+++ b/sources/en/n/novelfire.py
@@ -21,7 +21,7 @@ class NovelFireCrawler(Crawler):
         self.novel_author = soup.select_one('span[itemprop="author"]').text.strip()
 
         img = soup.select_one(".cover img")
-        self.novel_cover = self.absolute_url(img["data-src"])
+        self.novel_cover = self.absolute_url(img["src"])
 
         vol_id = 1
         vol_url = self.novel_url + "/chapters"


### PR DESCRIPTION
Patches novelfire scrapes. `data-src` was being used as an image selector, it appears that it is now located in a attribute simply called `src`

Previous Error:
```

Retrieving novel info...

 ❗ Error: 'data-src' 
<class 'KeyError'>
File "lncrawl/bots/console/integration.py", line 109, in _download_novel
    self.app.get_novel_info()
  File "lncrawl/core/app.py", line 185, in get_novel_info
    self.crawler.read_novel_info()
  File "/home/vibrantclouds/.lncrawl/sources/en/n/novelfire.py", line 24, in read_novel_info
    self.novel_cover = self.absolute_url(img["data-src"])
  File "bs4/element.py", line 2214, in __getitem__
```

Fixed output
```
python lncrawl crawl https://novelfire.net/book/shadow-slave
╭──────────────────────────────────────────────────────────────────────╮
│ https://novelfire.net/book/shadow-slave                              │
│ Shadow Slave                                                         │
│ Guiltythree                                                          │
│ 28 volumes, 2736 chapters                                            │
╰──────────────────────────────────────────────────────────────────────╯
```