### PR TITLE
Handle virtual environments appropriately based on OS

### DIFF
--- a/setup_pyi.py
+++ b/setup_pyi.py
@@ -9,7 +9,15 @@ if sys.version_info[:2] < (3, 8):
 
 ROOT = Path(__file__).resolve().parent
 
-VENV_DIR = Path(os.getenv("VIRTUAL_ENV", ".venv")).relative_to(ROOT).as_posix()
+# Determine venv directory: use VIRTUAL_ENV if set, otherwise detect based on OS
+if os.getenv("VIRTUAL_ENV"):
+    VENV_DIR = Path(os.getenv("VIRTUAL_ENV")).relative_to(ROOT).as_posix()
+elif (ROOT / ".venv-win").exists():
+    VENV_DIR = ".venv-win"
+elif (ROOT / ".venv-posix").exists():
+    VENV_DIR = ".venv-posix"
+else:
+    VENV_DIR = ".venv"
 AVAILABLE_SITE_PACKAGES = list(ROOT.glob(f"{VENV_DIR}/**/site-packages"))
 if not AVAILABLE_SITE_PACKAGES:
     raise RuntimeError(f"No site-packages found in {VENV_DIR}")


### PR DESCRIPTION
I develop on a Linux OS
While attempting to build  https://github.com/lncrawl/lightnovel-crawler/pull/2838 I noticed that `make setup` created a `.venv-posix` venv appropriately which `make install-py` installed the packages correctly into.

When trying to run `make build-exe` to create the executable however, I was running into this error:
```
.venv-posix/bin/python setup_pyi.py
Traceback (most recent call last):
  File "/home/vibrantclouds/Development/lightnovel-crawler/setup_pyi.py", line 12, in <module>
    VENV_DIR = Path(os.getenv("VIRTUAL_ENV", ".venv")).relative_to(ROOT).as_posix()
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/usr/lib64/python3.13/pathlib/_local.py", line 385, in relative_to
    raise ValueError(f"{str(self)!r} is not in the subpath of {str(other)!r}")
ValueError: '.venv' is not in the subpath of '/home/vibrantclouds/Development/lightnovel-crawler'
make: *** [Makefile:68: build-exe] Error 1
```

It seemed that `setup_pyi.py` defaults to `.venv` when `VIRTUAL_ENV` isn't set, but the makefile uses `.venv-posix` on linux by default instead!

This little tweak checks for the .env variable first and uses that if applicable, otherwise it'll attempt to see if `.venv-win` or `.venv-posix` exists, using that instead. It will again default to `.venv` if it cannot find either of those directories.

This allows the process of 1) `make setup` 2) `make install-py` 3) `make-build-exe` function smoothly on a fresh clone on a Linux machine!