### PR TITLE
Python Compatibility Tweaks

### DIFF
--- a/lncrawl/server/api/jobs.py
+++ b/lncrawl/server/api/jobs.py
@@ -87,7 +87,7 @@ def fetch_novel(
     user: User = Security(ensure_user),
     body: FetchNovelRequest = Body(),
 ) -> Job:
-    url = body.url.encoded_string()
+    url = str(body.url)
     return ctx.jobs.fetch_novel(user, url, full=body.full)
 
 

--- a/lncrawl/server/api/meta.py
+++ b/lncrawl/server/api/meta.py
@@ -37,7 +37,7 @@ def list_supported_sources():
 def get_favicon(
     url: HttpUrl = Query(description='URL'),
 ) -> FileResponse:
-    file = ctx.http.favicon(url.encoded_string())
+    file = ctx.http.favicon(str(url))
     return FileResponse(
         file,
         filename='favicon.ico',

--- a/lncrawl/services/crawler/service.py
+++ b/lncrawl/services/crawler/service.py
@@ -43,7 +43,7 @@ class CrawlerService:
             url = HttpUrl(url)
         if not url.host:
             raise ServerErrors.invalid_url.with_extra(url)
-        novel_url = url.encoded_string()
+        novel_url = str(url)
 
         # get crawler
         can_close = False
@@ -137,7 +137,7 @@ class CrawlerService:
         model = ChapterModel(
             id=chapter.serial,
             title=chapter.title,
-            url=url.encoded_string(),
+            url=str(url),
             extras=chapter.extra,
         )
         model.body = crawler.download_chapter_body(model).strip()
@@ -190,7 +190,7 @@ class CrawlerService:
 
         # download image
         file = ctx.files.resolve(image.image_file)
-        download_image(crawler, url.encoded_string(), file)
+        download_image(crawler, str(url), file)
 
         # update db
         with ctx.db.session() as sess:

--- a/lncrawl/services/sources/utils.py
+++ b/lncrawl/services/sources/utils.py
@@ -100,12 +100,12 @@ def import_crawlers(file: Path) -> Generator[Type[Crawler], None, None]:
         mod_name = hashlib.md5(file.name.encode()).hexdigest()
         spec = importlib.util.spec_from_file_location(mod_name, file)
         if not (spec and spec.loader):
-            logger.info(f"[{file}] Unexpected spec")
+            logger.info(f"\\[{file}] Unexpected spec")
             return
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
     except Exception as e:
-        logger.info(f"[{file}] Failed to load: {repr(e)}")
+        logger.info(f"\\[{file}] Failed to load: {repr(e)}")
         return
 
     # import all valid crawlers
@@ -124,10 +124,10 @@ def import_crawlers(file: Path) -> Generator[Type[Crawler], None, None]:
 
         # required method checks
         if not has_method(crawler, 'read_novel_info'):
-            logger.info(f"[{file}] Missing required method 'read_novel_info'")
+            logger.info(f"\\[{file}] Missing required method 'read_novel_info'")
             continue
         if not has_method(crawler, 'download_chapter_body'):
-            logger.info(f"[{file}] Missing required method 'download_chapter_body'")
+            logger.info(f"\\[{file}] Missing required method 'download_chapter_body'")
             continue
 
         # base url checks
@@ -136,7 +136,7 @@ def import_crawlers(file: Path) -> Generator[Type[Crawler], None, None]:
         urls = [str(url).lower().strip("/") + "/" for url in urls]
         urls = [url for url in set(urls) if validate_url(url)]
         if not urls:
-            logger.info(f"[{file}] No base url: {crawler}")
+            logger.info(f"\\[{file}] No base url: {crawler}")
             continue
 
         # static values


### PR DESCRIPTION
Partial update of #2858 

Bracket string escapes added to `utils.py` solves `MarkupError` during pipeline builds, see: https://github.com/VibrantClouds/lightnovel-crawler/actions/runs/21377160806

Switches `encoded_string()` usage to more standardized `str(x)` syntax for backwards compatibility in older python versions. This works on recent versions, but as you're including some older versions in the version matrix, this consistently works.  see: https://github.com/VibrantClouds/lightnovel-crawler/actions/runs/21377572883/job/61537208423

`encoded_string()` may be valid if you are willing to drop certain versions of Python's support. (Version pinning to Pydantic 1.x may be viable?)

Through testing, `str()` works just fine here though!