### PR TITLE
fix: ranobelib.me crawler — API header, branch selection, DB bootstrap

### DIFF
--- a/lncrawl/commands/crawl.py
+++ b/lncrawl/commands/crawl.py
@@ -89,9 +89,8 @@ def crawl(
             crawler.login(username, password)
 
     # fetch novel details
-    with console.status("Fetching novel details..."):
-        user = ctx.users.get_admin()
-        novel = ctx.crawler.fetch_novel(user.id, url, crawler=crawler)
+    user = ctx.users.get_admin()
+    novel = ctx.crawler.fetch_novel(user.id, url, crawler=crawler)
     print(
         Panel(
             "\n".join(

--- a/lncrawl/services/db.py
+++ b/lncrawl/services/db.py
@@ -82,7 +82,18 @@ class DB:
         self._ensure_database()
         base = self.base_revision()
         if base and self.has_any_tables() and not self.current_revision():
-            command.stamp(self.alembic_config, base)
+            # Only stamp base if all tables from the initial migration exist.
+            # Otherwise, drop the incomplete schema and let migrations recreate it.
+            from ..dao import SQLModel
+
+            expected = set(SQLModel.metadata.tables.keys())
+            with self.engine.connect() as conn:
+                actual = set(sa.inspect(conn).get_table_names())
+            if expected - {"alembic_version"} <= actual:
+                command.stamp(self.alembic_config, base)
+            else:
+                logger.warning("Incomplete schema detected, recreating database tables.")
+                SQLModel.metadata.drop_all(self.engine)
         command.upgrade(self.alembic_config, "head")
 
     @cached_property

--- a/sources/ru/ranobelib.py
+++ b/sources/ru/ranobelib.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
-import operator
+from collections import Counter
 from urllib.parse import urlencode
 
 from lncrawl.core import Crawler
@@ -16,6 +16,7 @@ class RanobeLibMeCrawler(Crawler):
 
     def initialize(self):
         self.init_executor(ratelimit=0.99)
+        self.scraper.headers["Site-Id"] = "3"
         clean_url = self.novel_url.split("?")[0].strip("/")
         self.api_url = f"https://api.cdnlibs.org/api/manga/{clean_url.split('/')[-1]}"
 
@@ -57,29 +58,77 @@ class RanobeLibMeCrawler(Crawler):
         logger.info("Novel tags: %s", self.novel_tags)
 
         chapters = self.get_json(f"{self.api_url}/chapters")["data"]
+
+        # Count chapters per branch and collect all team names
+        branch_counts = Counter()
+        branch_teams = {}
+        for chapter in chapters:
+            for b in chapter["branches"]:
+                bid = b["branch_id"]
+                branch_counts[bid] += 1
+                if bid not in branch_teams:
+                    branch_teams[bid] = set()
+                for t in b.get("teams", []):
+                    name = t.get("name", "").strip()
+                    if name:
+                        branch_teams[bid].add(name)
+
+        # Let the user set branch priorities by sequential selection
+        if len(branch_counts) > 1:
+            remaining = [
+                (bid, count) for bid, count in branch_counts.most_common()
+            ]
+            priority = []
+
+            while remaining:
+                print()
+                if not priority:
+                    print("Select primary translation:")
+                else:
+                    print(f"Next priority ({len(priority)} selected):")
+                for i, (bid, count) in enumerate(remaining, 1):
+                    teams = ", ".join(sorted(branch_teams.get(bid, set()))) or f"Branch {bid}"
+                    print(f"  {i}) {teams} ({count} chapters)")
+                if priority:
+                    print(f"  0) Done")
+
+                try:
+                    raw = input("Choice: ").strip()
+                except (EOFError, KeyboardInterrupt):
+                    break
+
+                if raw == "0" and priority:
+                    break
+
+                try:
+                    idx = int(raw) - 1
+                    if 0 <= idx < len(remaining):
+                        pick = remaining.pop(idx)
+                        priority.append(pick[0])
+                    else:
+                        print("Invalid number")
+                except ValueError:
+                    print("Enter a number")
+
+            if not priority:
+                raise SystemExit("Cancelled by user")
+        elif branch_counts:
+            priority = [next(iter(branch_counts))]
+        else:
+            priority = []
+
         chap_id = 0
-
-        branches = dict()
         for chapter in chapters:
-            for branch in chapter["branches"]:
-                key = branch["branch_id"]
-            branches[key] = branches.setdefault(key, 0) + 1
-        branch = max(branches.items(), key=operator.itemgetter(1))[0]
-        if not isinstance(branch, int):
-            branch = 0
-
-        for chapter in chapters:
-            if any("moderation" in chapter_branch for chapter_branch in chapter["branches"]):
+            if any("moderation" in cb for cb in chapter["branches"]):
                 continue
 
-            """ Left it temporarily, to be fixed later """
-            # if not any(
-            #     chapter_branch["branch_id"] == branch
-            #     for chapter_branch in chapter["branches"]
-            # ):
-            #     continue
+            # Pick the highest-priority branch available for this chapter
+            available = {cb["branch_id"] for cb in chapter["branches"]}
+            branch = next((bid for bid in priority if bid in available), None)
+            if branch is None:
+                continue
 
-            chap_id = chap_id + 1
+            chap_id += 1
             chap_num = chapter["number"]
 
             params = {
@@ -92,7 +141,7 @@ class RanobeLibMeCrawler(Crawler):
                 Chapter(
                     id=chap_id,
                     url=f"{self.api_url}/chapter?{urlencode(params, doseq=True)}",
-                    title=chapter["name"] or f"Глава {chap_num}",
+                    title=chapter["name"] or f"Chapter {chap_num}",
                 )
             )
 


### PR DESCRIPTION
## Summary

This PR fixes multiple issues with the **ranobelib.me** crawler and two related infrastructure bugs.

### Changes

#### `sources/ru/ranobelib.py`

1. **Add `Site-Id: 3` header** — The ranobelib API (`api.cdnlibs.org`) now requires a `Site-Id` header. Without it, all API requests return 404. The value `3` corresponds to ranobelib.me (discovered from ranobelib's frontend JS bundle).

2. **Fix branch counting bug** — The original code had an indentation error: `branches[key] += 1` was outside the inner `for branch in chapter["branches"]` loop, so only the *last* branch per chapter was counted. Replaced with `collections.Counter` for correctness.

3. **Add translation branch priority selection** — When a novel has multiple translation branches (parallel translations by different teams), the user is now prompted to select priorities interactively. Chapters are then downloaded from the highest-priority available branch, with fallback to lower-priority branches.

4. **Show all team names per branch** — Collects all translation team names across all chapters in a branch (since branches can change teams over time), displaying them in the selection prompt.

#### `lncrawl/services/db.py`

5. **Fix DB bootstrap for incomplete schemas** — The `bootstrap()` method previously stamped the base Alembic migration as complete if *any* tables existed. If the schema was incomplete (e.g. from a corrupted or outdated DB), migrations would silently skip, causing `no such table` errors at runtime. Now checks that all expected tables exist before stamping; if the schema is incomplete, drops and recreates.

#### `lncrawl/commands/crawl.py`

6. **Remove Rich spinner around `fetch_novel()`** — The `console.status()` spinner captures stdin, preventing any `input()` calls inside crawlers from working. Removed the spinner wrapper so interactive prompts (like branch selection) work correctly.

### Testing

Tested with:
```
uv run python -m lncrawl crawl "https://ranobelib.me/ru/book/20818--lord-of-the-mysteries" --first 2
```
- Novel metadata fetched correctly (title, author, cover, tags)
- All 5 translation branches displayed with correct chapter counts and team names
- Branch selection works interactively
- Chapters download successfully