### PR TITLE
Fix novelight: chapter list and chapter body parsing

### DIFF
--- a/sources/en/n/novelight.py
+++ b/sources/en/n/novelight.py
@@ -47,7 +47,7 @@ class NoveLightCrawler(BrowserTemplate):
 
         return book_id, csrf
 
-    def parse_chapter_tags(self, soup: PageSoup, novel: Novel) -> Iterable[PageSoup]:
+    def select_chapter_tags(self, soup: PageSoup, novel: Novel) -> Iterable[PageSoup]:
         book_id, csrf = self._extract_book_tokens(soup)
         novel.book_id = book_id
         novel.csrf = csrf
@@ -90,7 +90,7 @@ class NoveLightCrawler(BrowserTemplate):
         }
         url = chapter.url.replace("chapter", "ajax/read-chapter")
         data = self.scraper.get_json(url, headers=headers)
-        soup = data["content"]
+        soup = self.scraper.make_soup(data["content"])
         contents = soup.select_one(".chapter-text")
         self.cleaner.clean_contents(contents)
         chapter.body = contents.inner_html


### PR DESCRIPTION
- Rename parse_chapter_tags to select_chapter_tags so the override is actually invoked by the template (the hook was renamed in the April 2026 template refactor; novelight was missed). Without this, the default select_chapter_tags ran against the pagination dropdown and persisted every chapter with an empty url, which later crashed HttpUrl(chapter.url) in fetch_chapter.
- Parse the AJAX read-chapter response with make_soup; data["content"] is an HTML string, not a soup, so select_one was raising AttributeError.