### PR TITLE
Fix novelbin and related NovelFull-based sources

### DIFF
--- a/lncrawl/templates/novelfull.py
+++ b/lncrawl/templates/novelfull.py
@@ -62,6 +62,5 @@ class NovelFullTemplate(BrowserTemplate):
         chapter.url = self.absolute_url(soup["href"] or soup["value"])
 
     def parse_chapter_body(self, soup: PageSoup, chapter: Chapter) -> None:
-        contents = soup.select_one("#chr-content, #chapter-content")
-        contents.decompose("div")
-        chapter.body = contents.inner_html
+        soup.decompose("div")
+        chapter.body = soup.inner_html

--- a/sources/en/n/novel-bin.net.py
+++ b/sources/en/n/novel-bin.net.py
@@ -11,4 +11,4 @@ class Novel_Bin_Net(NovelFullTemplate):
     base_url = ["https://novel-bin.net/"]
 
     def initialize(self) -> None:
-        self.init_executor(ratelimit=1)
+        self.taskman.init_executor(ratelimit=1)

--- a/sources/en/n/novelbin.py
+++ b/sources/en/n/novelbin.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 import logging
+from typing import Iterable, Optional
 
+from lncrawl.core import Novel, PageSoup, Volume
+from lncrawl.exceptions import LNException
 from lncrawl.templates.novelfull import NovelFullTemplate
 
 logger = logging.getLogger(__name__)
@@ -10,4 +13,17 @@ class NovelbinCrawler(NovelFullTemplate):
     base_url = ["https://novelbin.com/"]
 
     def initialize(self) -> None:
-        self.init_executor(ratelimit=0.99)
+        self.taskman.init_executor(ratelimit=0.99)
+
+    def select_chapter_tags(
+        self,
+        tag: PageSoup,
+        novel: Novel,
+        volume: Optional[Volume] = None,
+    ) -> Iterable[PageSoup]:
+        nl_id = tag.select_one("#rating[data-novel-id]")["data-novel-id"]
+        if not nl_id:
+            raise LNException("No novel_id found")
+        url = f"{self.scraper.origin}ajax/chapter-option?novelId={nl_id}"
+        soup = self.scraper.get_soup(url)
+        return soup.select("select > option[value]")

--- a/sources/en/n/novelhulk.py
+++ b/sources/en/n/novelhulk.py
@@ -10,4 +10,4 @@ class NovelHulkCrawler(NovelFullTemplate):
     base_url = ["https://novelhulk.com/"]
 
     def initialize(self):
-        self.init_executor(workers=2)
+        self.taskman.init_executor(workers=2)

--- a/sources/en/n/novelnext.py
+++ b/sources/en/n/novelnext.py
@@ -11,7 +11,7 @@ class NovelNextCrawler(NovelFullTemplate):
     base_url = ["https://novelnext.com/", "https://novelnext.dramanovels.io/"]
 
     def initialize(self) -> None:
-        self.init_executor(ratelimit=0.2)
+        self.taskman.init_executor(ratelimit=0.2)
         self.cleaner.bad_tag_text_pairs.update(
             {
                 "h4": [


### PR DESCRIPTION
- Replace `self.init_executor(...)` with `self.taskman.init_executor(...)` in novelbin, novel-bin.net, novelhulk, novelnext. The new Crawler base composes a `taskman` and does not expose `init_executor` directly the way LegacyCrawler does, so the call raised AttributeError during source initialization.
- novelbin.com: override `select_chapter_tags` to hit `/ajax/chapter-option?novelId=<slug>`. The template's hardcoded `/ajax-chapter-option` returns 404 here, and the `/ajax/chapter-archive` fallback responds with lazy-loaded markup whose chapters live inside a `<template>` element, so neither the `ul.list-chapter` nor the `select > option` selector matched and the chapter list ended up silently empty.
- novelfull template: drop the redundant `#chr-content, #chapter-content` re-selection in `parse_chapter_body`; `soup` is already the body tag selected via `chapter_body_selector`.