### PR TITLE
Fix empty chapter bodies in novelfull template

### DIFF
--- a/lncrawl/templates/novelfull.py
+++ b/lncrawl/templates/novelfull.py
@@ -62,6 +62,5 @@ class NovelFullTemplate(BrowserTemplate):
         chapter.url = self.absolute_url(soup["href"] or soup["value"])
 
     def parse_chapter_body(self, soup: PageSoup, chapter: Chapter) -> None:
-        contents = soup.select_one("#chr-content, #chapter-content")
-        contents.decompose("div")
-        chapter.body = contents.inner_html
+        soup.decompose("div")
+        chapter.body = soup.inner_html


### PR DESCRIPTION
Hit this while trying to download a novel from readnovelfull — the EPUB came out with every chapter empty except for the title. The on-disk chapter zst files were 9 bytes each (an empty zstd frame), so the problem was upstream of the EPUB binder, in the crawler itself.

Root cause is in `lncrawl/templates/novelfull.py`. After the BrowserTemplate refactor (`b93f86b1`), the base `download_chapter` selects the body via `chapter_body_selector` and passes that element into `parse_chapter_body`. But the novelfull template kept its old body — it called `soup.select_one("#chr-content, #chapter-content")` on the soup it received. BeautifulSoup's `select_one` only matches descendants (never self), so the nested lookup returned an empty `PageSoup`, `decompose("div")` no-oped, and `inner_html` came out as `""`. Every chapter saved as empty.

The template is shared, so this hit `novelfull`, `readnovelfull`, `allnovelfull`, `hotnovelfull`, `novelfullme`, and `novelfullplus`.

Fix is to just drop the redundant `select_one` and work on the soup we're handed:

```python
def parse_chapter_body(self, soup: PageSoup, chapter: Chapter) -> None:
    soup.decompose("div")
    chapter.body = soup.inner_html
```

## Test plan
- `lncrawl crawl --noin --first 5 -f epub https://readnovelfull.com/im-actually-a-cultivation-bigshot-v1.html` — each stored chapter is now ~3-4 KB compressed / ~8-9 KB decompressed of real HTML, and `chapter_000NN.xhtml` inside the EPUB contains the full chapter text.
- Worth a quick sanity check on one of the other affected sites (e.g. `novelfull.com`) before merging.