### PR TITLE
Fix resume — skip chapter download when content file already exists

### DIFF
--- a/lncrawl/services/crawler.py
+++ b/lncrawl/services/crawler.py
@@ -129,11 +129,7 @@ class CrawlerService:
         crawler.scraper.signal = signal
 
         # check if download is necessary
-        if (
-            not refresh
-            and chapter.is_available
-            and chapter.extra.get("crawler_version") == crawler.version
-        ):
+        if not refresh and chapter.is_available:
             logger.debug(f"Skipped: {novel.title}] - Chapter {chapter.serial}")
             return chapter
 


### PR DESCRIPTION
Re-running `lncrawl crawl --noin --all -f epub <URL>` on a half-finished novel re-downloaded every single already-saved chapter instead of resuming. With 1016/1734 chapters on disk and a long crawl interrupted by Cloudflare, I was watching it start over from zero every time.

The skip condition in `CrawlerService.fetch_chapter` looks fine at first glance:

```python
if (
    not refresh
    and chapter.is_available
    and chapter.extra.get("crawler_version") == crawler.version
):
    return chapter   # skip
```

…but `crawler_version` is a **declared** parameter on `CrawlerChapter` (`lncrawl/core/models.py:123`), and `_ModelBox.get_extras()` returns *only kwargs beyond declared params*. So when `fetch_chapter` does `chapter.extra.update(model.get_extras())` at save time, `crawler_version` is filtered out — it's never written to the JSON `extra` blob. `chapter.extra.get("crawler_version")` is `None` forever, never equals the int `crawler.version`, and the skip never fires.

Verified empirically on the test DB: every completed chapter has `extra = {}`. Nothing was being written.

There's a deeper hole behind this — `crawler.version` is set to `int(file.st_mtime)` of the source crawler file (`lncrawl/services/sources/helper.py:152`), which changes on `git checkout`, OneDrive sync, an editor save, etc. Even if the persistence were fixed, the comparison would be fragile. Storing the version in a proper DAO column is the long-term answer, but that's a migration and out of scope for "make resume work."

This PR keeps the change minimal: trust the on-disk file. If the chapter file exists, skip the download. Anyone who really wants to re-fetch already has `--refresh`.

```python
if not refresh and chapter.is_available:
    return chapter
```

## Test plan
- Run `lncrawl crawl --noin --all -f <fmt> <URL>` on a partially-downloaded novel. Confirm the progress bar zooms through the already-on-disk chapters (≈1000+ c/s) and only the missing ones actually hit the network.
- Verified locally: a 1734-chapter novel with 1016 on-disk chapters processed the first 1020 in under a second, then slowed to live download speed for the rest.