### PR TITLE
Preserve is_done (and merge extras) during ChapterService.sync

### DIFF
--- a/lncrawl/services/chapters.py
+++ b/lncrawl/services/chapters.py
@@ -208,7 +208,8 @@ class ChapterService:
                             novel_id=novel_id,
                             url=wanted[s].url,
                             title=wanted[s].title,
-                            extra=wanted[s].get_extras(),
+                            is_done=existing[s].is_done,
+                            extra={**existing[s].extra, **wanted[s].get_extras()},
                             volume_id=vol_id_map.get(wanted[s].volume),
                         ).model_dump()
                         for s in to_update


### PR DESCRIPTION
Noticed this while chasing down why a half-finished crawl wouldn't resume. After my first run downloaded 1016/1734 chapters of a novel, the DB had `is_done=1` on those 1016 rows. Re-running the same `lncrawl crawl` command and inspecting the DB afterwards showed only 26 rows with `is_done=1`. Every chapter had been silently reset.

Cause is in `ChapterService.sync`. The update branch constructs a brand-new `Chapter(...)` per row from the incoming `CrawlerChapter`:

```python
if to_update:
    sess.exec(
        sq.update(Chapter),
        params=[
            Chapter(
                id=existing[s].id,
                serial=s,
                novel_id=novel_id,
                url=wanted[s].url,
                title=wanted[s].title,
                extra=wanted[s].get_extras(),
                volume_id=vol_id_map.get(wanted[s].volume),
            ).model_dump()
            for s in to_update
        ],
    )
```

`is_done` isn't passed, so the DAO default (`False`) lands in `model_dump()`, and the UPDATE writes it back to the row. Same line of thinking applies to `extra`: `wanted[s].get_extras()` overwrites the column wholesale, so anything that had been written there since the last sync is gone.

`fetch_novel` runs `sync` every time it's called, so the flag is wiped on every novel fetch — and the interactive "Downloaded chapters only" choice in `_prompt_range_selection` (which filters by `is_done`) silently becomes useless.

Fix is small: preserve the existing `is_done`, and merge the existing `extra` with the new extras instead of replacing:

```python
is_done=existing[s].is_done,
extra={**existing[s].extra, **wanted[s].get_extras()},
```

## Test plan
- Download a few chapters of any novel, confirm `is_done=1` is set on those rows.
- Re-run `lncrawl crawl` on the same URL with `--noin --all`. Re-inspect: the previously-done rows should still report `is_done=1` (before this fix they would all be `0`).
- Run the interactive crawl flow and check that the "Downloaded chapters only" choice returns the expected set after a re-sync.