### PR TITLE
katreadingcafe: Fix chapter link validation logic

### DIFF
--- a/sources/en/b/botitranslation.py
+++ b/sources/en/b/botitranslation.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+import logging
+from typing import Generator, Optional, Union
+
+from bs4 import BeautifulSoup, Tag
+
+from lncrawl.models import Chapter, Volume
+from lncrawl.templates.soup.general import GeneralSoupTemplate
+
+logger = logging.getLogger(__name__)
+
+
+class BotiTranslationCrawler(GeneralSoupTemplate):
+    base_url = "https://www.botitranslation.com/"
+
+    def parse_title(self, soup: BeautifulSoup) -> str:
+        """Return the novel title from the novel page."""
+        #raise NotImplementedError()  # e.g. return soup.select_one("h1.title").get_text(strip=True)
+        return soup.select_one("div.book-name span").get_text()
+
+    def parse_cover(self, soup: BeautifulSoup) -> Optional[str]:
+        """Return the cover image URL, or '' if none."""
+
+        #return ""
+
+        return soup.select_one("div.cover img.cover-img").get_text()
+
+    def parse_chapter_list(
+        self, soup: BeautifulSoup
+    ) -> Generator[Union[Chapter, Volume], None, None]:
+        links = soup.select("tr td a")
+        for idx, a in enumerate(links, 1):
+            yield Chapter(
+                id=idx,
+                title=a.get_text(strip=True),
+                url=self.absolute_url(a["href"]),
+            )
+        logger.info("Found %d chapters", len(links))
+
+    def select_chapter_body(self, soup: BeautifulSoup) -> Optional[Tag]:
+        """Return the Tag that contains the chapter text (soup is the chapter page)."""
+
+        return soup.select_one("div.chapter-content")
+
+        #raise NotImplementedError()  # e.g. return soup.select_one(".chapter-content")

--- a/sources/en/b/botitranslation.py
+++ b/sources/en/b/botitranslation.py
@@ -2,44 +2,28 @@
 import logging
 from typing import Generator, Optional, Union
 
-from bs4 import BeautifulSoup, Tag
-
-from lncrawl.models import Chapter, Volume
-from lncrawl.templates.soup.general import GeneralSoupTemplate
+from lncrawl.core import Chapter, Novel, PageSoup, SoupTemplate, Volume, BrowserTemplate
 
 logger = logging.getLogger(__name__)
 
 
-class BotiTranslationCrawler(GeneralSoupTemplate):
+class BotiTranslationCrawler(SoupTemplate):
     base_url = "https://www.botitranslation.com/"
 
-    def parse_title(self, soup: BeautifulSoup) -> str:
-        """Return the novel title from the novel page."""
-        #raise NotImplementedError()  # e.g. return soup.select_one("h1.title").get_text(strip=True)
-        return soup.select_one("div.book-name span").get_text()
+    novel_title_selector = ".info-section .book-name span"
+    novel_author_selector = ".info-section .author-name"
+    novel_cover_selector = ".cover img.cover-img[src]"
 
-    def parse_cover(self, soup: BeautifulSoup) -> Optional[str]:
-        """Return the cover image URL, or '' if none."""
-
-        #return ""
-
-        return soup.select_one("div.cover img.cover-img").get_text()
+    chapter_body_selector = ".chapter-content"
 
     def parse_chapter_list(
-        self, soup: BeautifulSoup
+        self, soup: PageSoup, novel: Novel
     ) -> Generator[Union[Chapter, Volume], None, None]:
-        links = soup.select("tr td a")
-        for idx, a in enumerate(links, 1):
+        links = list(soup.select(".container div#toc-panel table tbody tr td a[href]"))
+        for idx, a in enumerate(links, 0):
             yield Chapter(
                 id=idx,
                 title=a.get_text(strip=True),
                 url=self.absolute_url(a["href"]),
             )
         logger.info("Found %d chapters", len(links))
-
-    def select_chapter_body(self, soup: BeautifulSoup) -> Optional[Tag]:
-        """Return the Tag that contains the chapter text (soup is the chapter page)."""
-
-        return soup.select_one("div.chapter-content")
-
-        #raise NotImplementedError()  # e.g. return soup.select_one(".chapter-content")

--- a/sources/en/b/brightnovels.py
+++ b/sources/en/b/brightnovels.py
@@ -8,20 +8,24 @@ from lncrawl.core import Chapter, Novel, PageSoup, SoupTemplate, Volume, Browser
 logger = logging.getLogger(__name__)
 
 
-class BotiTranslationCrawler(SoupTemplate):
-    base_url = ["https://www.botitranslation.com/"]
+class BrightNovelsCrawler(SoupTemplate):
+    base_url = ["https://brightnovels.com/"]
 
-    novel_title_selector = ".info-section .book-name span"
-    novel_author_selector = ".info-section .author-name"
-    novel_cover_selector = ".cover-img"
+    novel_title_selector = ".text-2xl"
+    novel_author_selector = "div.text-muted-foreground:nth-child(3)"
+    novel_cover_selector = ".w-48 > img:nth-child(1)"
+    novel_tags_selector = "div.flex:nth-child(4)"
 
-    novel_toc_selector = "#tocItems"
-    novel_synopsis_selector = "div#about-panel .content"
+    novel_toc_selector = "section.container:nth-child(2) > div:nth-child(1) > div:nth-child(2) > div:nth-child(2)"
+    novel_toc_free_chap_selector = ".space-y-4 > div:nth-child(1) > div:nth-child(1) > button:nth-child(2)" # select free chapters
+    novel_toc_prem_chap_icon_selector = "a.relative:nth-child(1) > div:nth-child(1) > div:nth-child(2) > svg.lucide-lock-icon"
+    novel_synopsis_selector = ".prose"
 
-    chapter_list_selector = "tr td a[href]"
-    chapter_title_selector = "#chapterContentTitle, .chapter-title"
+    chapter_list_reverse = True
+    chapter_list_selector = "section.container:nth-child(2) > div:nth-child(1) > div:nth-child(2) > div:nth-child(2) .grid a"
+    chapter_title_selector = ".flex .text-sm"
 
-    chapter_body_selector = "#chapterContent, .chapter-content"
+    chapter_body_selector = "#app > div > main > div > div > div.rounded-lg.border.bg-card.text-card-foreground.shadow-xs.relative.mb-10.overflow-hidden.p-6.md\:p-8 > div > div"
 
     auto_create_volumes = False
 
@@ -29,25 +33,35 @@ class BotiTranslationCrawler(SoupTemplate):
         self.taskman.init_executor(workers=2) 
         # The browser doesn't handle concurrency very well, likely due to networking limitations
 
+    def parse_tags(self, soup: PageSoup, novel: Novel) -> None:
+        """Parse and set the novel categories/genres/tags"""
+        #novel.tags = [tag.text for tag in soup.select(self.novel_tags_selector)]
+        for tag in soup.select(self.novel_tags_selector):
+            tag_text = tag.text
+            if "#" in tag_text:
+                tag_text = tag_text.strip("#") # Remove octothorpe from tags if applicable
+            novel.tags.append(tag_text)
+
     def parse_chapter_item(self, soup: PageSoup, chapter_id: int) -> Chapter:
         chapter = Chapter(id=chapter_id)
         self.parse_chapter_title(soup, chapter)
         self.parse_chapter_url(soup, chapter)
         return chapter
 
+    def parse_chapter_title(self, soup: PageSoup, chapter: Chapter) -> None:
+        """Parse and set the chapter title"""
+        title_tag = soup.select_one(self.chapter_title_selector) or soup
+        #print("Chapter title tag: " + str(title_tag))
+        print("Chapter title: " + title_tag.text)
+        chapter.title = title_tag.text
+
     def select_chapter_tags(
         self, soup: PageSoup, novel: Novel, volume: Optional[Volume] = None
     ) -> Iterable[PageSoup]:
         chapters = list(soup.select(self.chapter_list_selector))
-
-        for a in chapters:
-            if self._valid_chapter_link(a):
-                yield a
-
-    def _valid_chapter_link(self, link: PageSoup) -> bool:
-        if link.select("i.iconfont"): # Paywalled chapters have an icon within the link text
-            return False
-        return True
+        
+        for a in reversed(chapters):
+            yield a
 
     def download_chapter(self, chapter: Chapter) -> None:
         soup = self.get_chapter_soup(chapter, True)
@@ -59,25 +73,11 @@ class BotiTranslationCrawler(SoupTemplate):
         url = self.build_novel_url(novel)
         with self.create_browser() as browser:
             browser.visit(novel.url)
+            browser.click(self.novel_toc_free_chap_selector)
             browser.wait("#loadingMask", inverse=True, timeout=5)
             if extra_timeout: # For JS-heavy pages, call with extra_timeout=True
                 import time
                 time.sleep(2)
-            browser.click(".border-color > li:nth-child(2)") # click TOC for next section
-
-            # Since the TOC loads 100 chapters at a time, with more being loaded upon scrolling,
-            # the browser needs to scroll through all chapter items
-            previous_count = 0  
-            current_elements = browser.find_all("#tocItems tr td")
-            while True:  
-                for index, root in enumerate(current_elements):
-                    root.scroll_into_view() # Scroll to every TOC item
-                browser.wait("#loadingMask", inverse=True, timeout=2)
-                current_elements = browser.find_all("#tocItems tr td")
-                current_count = len(current_elements) 
-                if current_count == previous_count:  
-                    break  
-                previous_count = current_count
             
             soup = browser.soup
             return soup
@@ -86,7 +86,6 @@ class BotiTranslationCrawler(SoupTemplate):
         url = self.build_chapter_url(chapter)
         with self.create_browser() as browser:
             browser.visit(chapter.url)
-            browser.wait("#loadingMask", inverse=True, timeout=2)
             browser.wait(self.chapter_body_selector)
             if extra_timeout:
                 import time

--- a/sources/en/d/dreamytranslations.py
+++ b/sources/en/d/dreamytranslations.py
@@ -8,20 +8,22 @@ from lncrawl.core import Chapter, Novel, PageSoup, SoupTemplate, Volume, Browser
 logger = logging.getLogger(__name__)
 
 
-class BotiTranslationCrawler(SoupTemplate):
-    base_url = ["https://www.botitranslation.com/"]
+class DreamyTranslationsCrawler(SoupTemplate):
+    base_url = ["https://dreamy-translations.com/"]
 
-    novel_title_selector = ".info-section .book-name span"
-    novel_author_selector = ".info-section .author-name"
-    novel_cover_selector = ".cover-img"
+    novel_title_selector = ".text-2xl"
+    novel_author_selector = ".mt-1 > span:nth-child(1)"
+    novel_cover_selector = ".object-cover"
+    novel_tags_selector = "div.flex-wrap:nth-child(2) span, div.flex-wrap:nth-child(3) span"
 
     novel_toc_selector = "#tocItems"
-    novel_synopsis_selector = "div#about-panel .content"
+    novel_synopsis_selector = "div.min-h-0:nth-child(5) > div:nth-child(1)"
 
-    chapter_list_selector = "tr td a[href]"
-    chapter_title_selector = "#chapterContentTitle, .chapter-title"
+    chapter_list_selector = ".space-y-0\.5 a"
+    chapter_title_selector = "a.group > div:nth-child(1) > p"
 
-    chapter_body_selector = "#chapterContent, .chapter-content"
+    chapter_body_selector = "main article div"
+    chapter_elem_selector = ".paragraph .line"
 
     auto_create_volumes = False
 
@@ -29,11 +31,27 @@ class BotiTranslationCrawler(SoupTemplate):
         self.taskman.init_executor(workers=2) 
         # The browser doesn't handle concurrency very well, likely due to networking limitations
 
+    def parse_tags(self, soup: PageSoup, novel: Novel) -> None:
+        """Parse and set the novel categories/genres/tags"""
+        #novel.tags = [tag.text for tag in soup.select(self.novel_tags_selector)]
+        for tag in soup.select(self.novel_tags_selector):
+            tag_text = tag.text
+            if "#" in tag_text:
+                tag_text = tag_text.strip("#") # Remove octothorpe from tags if applicable
+            novel.tags.append(tag_text)
+
     def parse_chapter_item(self, soup: PageSoup, chapter_id: int) -> Chapter:
         chapter = Chapter(id=chapter_id)
         self.parse_chapter_title(soup, chapter)
         self.parse_chapter_url(soup, chapter)
         return chapter
+
+    def parse_chapter_title(self, soup: PageSoup, chapter: Chapter) -> None:
+        """Parse and set the chapter title"""
+        title_tag = soup.select_one(self.chapter_title_selector) or soup
+        #print("Chapter title tag: " + str(title_tag))
+        print("Chapter title: " + title_tag.text)
+        chapter.title = title_tag.text
 
     def select_chapter_tags(
         self, soup: PageSoup, novel: Novel, volume: Optional[Volume] = None
@@ -41,13 +59,7 @@ class BotiTranslationCrawler(SoupTemplate):
         chapters = list(soup.select(self.chapter_list_selector))
 
         for a in chapters:
-            if self._valid_chapter_link(a):
-                yield a
-
-    def _valid_chapter_link(self, link: PageSoup) -> bool:
-        if link.select("i.iconfont"): # Paywalled chapters have an icon within the link text
-            return False
-        return True
+            yield a
 
     def download_chapter(self, chapter: Chapter) -> None:
         soup = self.get_chapter_soup(chapter, True)
@@ -63,21 +75,6 @@ class BotiTranslationCrawler(SoupTemplate):
             if extra_timeout: # For JS-heavy pages, call with extra_timeout=True
                 import time
                 time.sleep(2)
-            browser.click(".border-color > li:nth-child(2)") # click TOC for next section
-
-            # Since the TOC loads 100 chapters at a time, with more being loaded upon scrolling,
-            # the browser needs to scroll through all chapter items
-            previous_count = 0  
-            current_elements = browser.find_all("#tocItems tr td")
-            while True:  
-                for index, root in enumerate(current_elements):
-                    root.scroll_into_view() # Scroll to every TOC item
-                browser.wait("#loadingMask", inverse=True, timeout=2)
-                current_elements = browser.find_all("#tocItems tr td")
-                current_count = len(current_elements) 
-                if current_count == previous_count:  
-                    break  
-                previous_count = current_count
             
             soup = browser.soup
             return soup

--- a/sources/en/k/katreadingcafe.py
+++ b/sources/en/k/katreadingcafe.py
@@ -146,7 +146,8 @@ class KatReadingCafeCrawler(SoupTemplate):
 
     def _valid_chapter_link(self, link: PageSoup) -> bool:
         href = link.get("href")
-        if href not in self.base_url:
+        stripped_base_url = str(self.base_url).strip("[]'")
+        if stripped_base_url not in href:
             return False
         if "🔒" in link.text:  # locked chapter
             return False

--- a/sources/en/l/lorenovels.py
+++ b/sources/en/l/lorenovels.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+import logging
+import re
+from typing import Iterable, Optional
+
+from lncrawl.core import Chapter, Novel, PageSoup, SoupTemplate
+
+logger = logging.getLogger(__name__)
+
+
+class LoreNovelsCrawler(SoupTemplate):
+    base_url = "https://lorenovels.com/"
+
+    novel_cover_selector = "main .entry-content .wp-block-group .wp-block-image img"
+    novel_title_selector = "div.is-vertical:nth-child(1) > h2:nth-child(2)"
+    novel_author_selector = "div.is-vertical:nth-child(2) > h2:nth-child(2)"
+    novel_tags_selector = "div.wp-block-group:nth-child(3) > h2:nth-child(2)" # remember to split via ", "
+    novel_synopsis_selector = ".wp-container-core-group-is-layout-7faab66b > p.wp-block-paragraph"
+    
+    chapter_list_reverse = True
+    chapter_list_selector = ".wp-block-latest-posts__list li"
+    chapter_url_selector = "a"
+
+    chapter_body_selector = "main .entry-content"
+
+    
+    def parse_tags(self, soup: PageSoup, novel: Novel) -> None:
+
+        for tag in soup.select(self.novel_tags_selector):
+            if ", " in tag.text:
+                multi_tag_subtags = tag.text.split(", ")
+                for individual_tag in multi_tag_subtags:
+                    novel.tags.append(individual_tag)
+        
+        if not novel.tags:
+           meta_tag = soup.select_one(SoupTemplate.novel_tags_selector)
+           novel.tags = [t.strip() for t in meta_tag.get("content").split(",")]
+    
+    def parse_summary(self, soup: PageSoup, novel: Novel) -> None:
+        tag = soup.select_one(self.novel_synopsis_selector)
+        novel.synopsis = self.cleaner.extract_contents(tag)
+        if not novel.synopsis:
+            meta_tag = soup.select_one(SoupTemplate.novel_synopsis_selector)
+            content = PageSoup.create(meta_tag.get("content"))
+            novel.synopsis = self.cleaner.extract_contents(content)
+    


### PR DESCRIPTION
Upon testing, this source didn't fetch chapters for multiple tested series. I messed around with the script a bit and it seemed that commenting out lines 149-150 caused the crawler to work, so I focused on testing there.

Seems like `self.base_url` was being passes as a List type, and for whatever reason that wasn't playing well with the comparison edited in the commit. So, I stringified the list, stripped the array characters, and used that as the comparison target instead, and it worked.

I'm very rusty with Python so please let me know if there was a better way to do this.

Tested and working with these three URLs:

- https://katreadingcafe.com/series/to-prevent-me-from-destroying-the-world-the-country-sent-people-cuddle-with-me/
- https://katreadingcafe.com/series/becoming-a-white-haired-evil-god-starts-from-wearing-the-ring-of-seven-curses/
- https://katreadingcafe.com/series/is-the-instance-you-made-actually-meant-for-players/

Example test from https://katreadingcafe.com/series/is-the-instance-you-made-actually-meant-for-players/:
```
>>> Parsing content
    class: <class 'b7ea6ae2f3ff838272d2ff528a8d7d4b.KatReadingCafeCrawler'>
    supported urls: https://katreadingcafe.com/
    login: False
    search: False
    language: 
    has_mtl: False
    has_manga: False
>>> Initializing crawler
    origin: https://katreadingcafe.com/
>>> Reading novel info
    url: https://katreadingcafe.com/series/is-the-instance-you-made-actually-meant-for-players/
    title: Is The Instance You Made Actually Meant For Players?
    cover: https://katreadingcafe.com/wp-content/uploads/2026/04/600_6.webp
    author: 
    language: 
    manga: None
    MTL: None
    tags: 
    extras: {}
    volumes: 1
    chapters: 94
<snip>
>>> Downloading chapter 1
    url: https://katreadingcafe.com/is-the-instance-you-made-actually-meant-for-players-volume-1-chapter-1-you-might-as-well-just-let-me-die
    title: 'Vol. 1 Ch. 1 - You Might As Well Just Let Me Die'
    volume: 1
    images: Box({'46eee0e7172d56aceacfc985df489503': 'https://katreadingcafe.com/wp-content/uploads/2026/04/NoCover.webp'})
    extras: {}
<snip>
>>> Downloading chapter 94
    url: https://katreadingcafe.com/abstract-instance-game-volume-1-chapter-94-era
    title: 'Vol. 1 Ch. 94 - Era'
    volume: 1
    images: Box({'c176e1f4693fe100984c1f0686e2cfda': 'https://katreadingcafe.com/wp-content/uploads/2026/04/NoCover.webp'})
    extras: {}
<snip>
TEST PASSED!
```