### PR TITLE
katreadingcafe: Fix chapter link validation logic

### DIFF
--- a/sources/en/k/katreadingcafe.py
+++ b/sources/en/k/katreadingcafe.py
@@ -147,9 +147,9 @@ class KatReadingCafeCrawler(SoupTemplate):
     def _valid_chapter_link(self, link: PageSoup) -> bool:
         href = link.get("href")
         for url in self.base_url:
-            if url in href: # found base url in the href
+            if url in href:  # found base url in the href
                 break
-        else: # href is a foreign url
+        else:  # href is a foreign url
             return False
         if "🔒" in link.text:  # locked chapter
             return False

--- a/sources/en/k/katreadingcafe.py
+++ b/sources/en/k/katreadingcafe.py
@@ -146,8 +146,10 @@ class KatReadingCafeCrawler(SoupTemplate):
 
     def _valid_chapter_link(self, link: PageSoup) -> bool:
         href = link.get("href")
-        stripped_base_url = str(self.base_url).strip("[]'")
-        if stripped_base_url not in href:
+        for url in self.base_url:
+            if url in href: # found base url in the href
+                break
+        else: # href is a foreign url
             return False
         if "🔒" in link.text:  # locked chapter
             return False

--- a/sources/en/k/katreadingcafe.py
+++ b/sources/en/k/katreadingcafe.py
@@ -146,7 +146,8 @@ class KatReadingCafeCrawler(SoupTemplate):
 
     def _valid_chapter_link(self, link: PageSoup) -> bool:
         href = link.get("href")
-        if href not in self.base_url:
+        stripped_base_url = str(self.base_url).strip("[]'")
+        if stripped_base_url not in href:
             return False
         if "🔒" in link.text:  # locked chapter
             return False


### PR DESCRIPTION
Upon testing, this source didn't fetch chapters for multiple tested series. I messed around with the script a bit and it seemed that commenting out lines 149-150 caused the crawler to work, so I focused on testing there.

Seems like `self.base_url` was being passes as a List type, and for whatever reason that wasn't playing well with the comparison edited in the commit. So, I stringified the list, stripped the array characters, and used that as the comparison target instead, and it worked.

I'm very rusty with Python so please let me know if there was a better way to do this.

Tested and working with these three URLs:

- https://katreadingcafe.com/series/to-prevent-me-from-destroying-the-world-the-country-sent-people-cuddle-with-me/
- https://katreadingcafe.com/series/becoming-a-white-haired-evil-god-starts-from-wearing-the-ring-of-seven-curses/
- https://katreadingcafe.com/series/is-the-instance-you-made-actually-meant-for-players/

Example test from https://katreadingcafe.com/series/is-the-instance-you-made-actually-meant-for-players/:
```
>>> Parsing content
    class: <class 'b7ea6ae2f3ff838272d2ff528a8d7d4b.KatReadingCafeCrawler'>
    supported urls: https://katreadingcafe.com/
    login: False
    search: False
    language: 
    has_mtl: False
    has_manga: False
>>> Initializing crawler
    origin: https://katreadingcafe.com/
>>> Reading novel info
    url: https://katreadingcafe.com/series/is-the-instance-you-made-actually-meant-for-players/
    title: Is The Instance You Made Actually Meant For Players?
    cover: https://katreadingcafe.com/wp-content/uploads/2026/04/600_6.webp
    author: 
    language: 
    manga: None
    MTL: None
    tags: 
    extras: {}
    volumes: 1
    chapters: 94
<snip>
>>> Downloading chapter 1
    url: https://katreadingcafe.com/is-the-instance-you-made-actually-meant-for-players-volume-1-chapter-1-you-might-as-well-just-let-me-die
    title: 'Vol. 1 Ch. 1 - You Might As Well Just Let Me Die'
    volume: 1
    images: Box({'46eee0e7172d56aceacfc985df489503': 'https://katreadingcafe.com/wp-content/uploads/2026/04/NoCover.webp'})
    extras: {}
<snip>
>>> Downloading chapter 94
    url: https://katreadingcafe.com/abstract-instance-game-volume-1-chapter-94-era
    title: 'Vol. 1 Ch. 94 - Era'
    volume: 1
    images: Box({'c176e1f4693fe100984c1f0686e2cfda': 'https://katreadingcafe.com/wp-content/uploads/2026/04/NoCover.webp'})
    extras: {}
<snip>
TEST PASSED!
```