### PR TITLE
fix(lightnovetrans): stop prepending origin to absolute novel url

### DIFF
--- a/sources/en/l/lightnovetrans.py
+++ b/sources/en/l/lightnovetrans.py
@@ -15,7 +15,7 @@ class LNTCrawler(SoupTemplate):
     chapter_body_selector = ".text_story"
 
     def build_novel_url(self, novel: Novel) -> str:
-        return f"{self.scraper.origin}{novel.url}/?tab=table_contents"
+        return f"{novel.url.rstrip('/')}/?tab=table_contents"
 
     def parse_author(self, soup: PageSoup, novel: Novel) -> None:
         authors = []


### PR DESCRIPTION
build_novel_url concatenated scraper.origin with novel.url, but novel.url
is already an absolute URL. That produced a malformed
"https://lightnovelstranslations.com/https://lightnovelstranslations.com/..."
which 404'd. Use novel.url directly and append the table_contents tab.

Fixes #3067