### PR TITLE
fixed source issue for novelfull half chapters being downloaded

### DIFF
--- a/lncrawl/templates/novelfull.py
+++ b/lncrawl/templates/novelfull.py
@@ -65,5 +65,4 @@ class NovelFullTemplate(SoupTemplate):
         for div in soup.find_all("div"):
             if not div.find("p"):
                 div.decompose()
-        # soup.decompose("div")
         chapter.body = soup.inner_html

--- a/lncrawl/templates/novelfull.py
+++ b/lncrawl/templates/novelfull.py
@@ -62,5 +62,8 @@ class NovelFullTemplate(SoupTemplate):
         chapter.url = self.absolute_url(soup["href"] or soup["value"])
 
     def parse_chapter_body(self, soup: PageSoup, chapter: Chapter) -> None:
-        soup.decompose("div")
+        for div in soup.find_all("div"):
+            if not div.find("p"):
+                div.decompose()
+        # soup.decompose("div")
         chapter.body = soup.inner_html


### PR DESCRIPTION
## What does this PR do?
Fixed the source for novelfull tempelate
<!-- One sentence summary. -->
Any paragraph inside div was ignored added the condition to check if there is any paragraph inside the div if yes not ignore it 
## Type of change

- [ partial chapter download/missing paragraphs] Bug fix
- [ ] New source
- [ ] Feature / enhancement
- [ ] Docs / chore

## Details
in the given novel the chapter after 580 only partial chapters were crawled because of the change in format of website hence fixed the template 
<!-- For source PRs: paste a novel URL you tested against.
     For bug fixes: describe what was wrong and what you changed.
     For features: explain the motivation and any trade-offs. -->

https://novelfull.net/cultivation-when-you-take-things-to-the-extreme/chapter-601-chapter-601-366-chapter-qiankun.html

## Checklist

- [ ] `make lint` passes with no errors
- [ ] Tested manually (crawl command or server)
