### PR TITLE
Use shutil.move to finalize artifacts across filesystems

### DIFF
--- a/lncrawl/services/binder/calibre.py
+++ b/lncrawl/services/binder/calibre.py
@@ -244,5 +244,5 @@ def convert_epub(
 
     out_file.parent.mkdir(parents=True, exist_ok=True)
     out_file.unlink(True)
-    tmp_file.rename(out_file)
+    shutil.move(str(tmp_file), str(out_file))
     logger.info("Created: %s", out_file.name)

--- a/lncrawl/services/binder/epub.py
+++ b/lncrawl/services/binder/epub.py
@@ -1,6 +1,7 @@
 import logging
 from pathlib import Path
 import re
+import shutil
 from threading import Event
 from typing import Optional
 
@@ -248,5 +249,5 @@ def make_epub(working_dir: Path, artifact: Artifact, signal=Event(), **kwargs) -
     epub.write_epub(str(tmp_file), book, {})
     out_file.parent.mkdir(parents=True, exist_ok=True)
     out_file.unlink(True)
-    tmp_file.rename(out_file)
+    shutil.move(str(tmp_file), str(out_file))
     logger.info(f"Created: {out_file}")

--- a/lncrawl/services/binder/json.py
+++ b/lncrawl/services/binder/json.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from pathlib import Path
+import shutil
 from threading import Event
 import zipfile
 
@@ -66,5 +67,5 @@ def make_json(working_dir: Path, artifact: Artifact, signal=Event(), **kwargs) -
 
     out_file.parent.mkdir(parents=True, exist_ok=True)
     out_file.unlink(True)
-    tmp_file.rename(out_file)
+    shutil.move(str(tmp_file), str(out_file))
     logger.info(f"Created: {out_file}")

--- a/lncrawl/services/binder/text.py
+++ b/lncrawl/services/binder/text.py
@@ -1,5 +1,6 @@
 import logging
 from pathlib import Path
+import shutil
 from threading import Event
 import zipfile
 
@@ -76,5 +77,5 @@ def make_text(working_dir: Path, artifact: Artifact, signal=Event(), **kwargs) -
 
     out_file.parent.mkdir(parents=True, exist_ok=True)
     out_file.unlink(True)
-    tmp_file.rename(out_file)
+    shutil.move(str(tmp_file), str(out_file))
     logger.info(f"Created: {out_file}")


### PR DESCRIPTION
pathlib.Path.rename relies on os.rename, which fails with OSError
[Errno 18] Invalid cross-device link when the temp working dir and the
output dir live on different mounts (e.g. local SSD for tmp, NFS/SMB for
storage). Replace it with shutil.move in every binder that finalizes an
artifact (epub, json, text, calibre), which falls back to copy+delete
across devices.