### PR TITLE
Support single-volume artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Single-volume artifacts** — `POST /api/jobs/create/make-artifacts` accepts an optional `volume` (volume serial number) to build an e-book covering just that volume; artifacts record the volume in a new `volume` column (new `artifact_volume_column` migration) and can be filtered by it via `GET /api/artifacts`. Whole-novel listings (`list_latest`/novel page/download emails) still show only full-novel artifacts
+
 ## [4.12.0] - 2026-07-14
 
 ### Added

--- a/lncrawl/dao/artifact.py
+++ b/lncrawl/dao/artifact.py
@@ -15,6 +15,12 @@ class Artifact(BaseTable, table=True):
     job_id: Optional[str] = sa.Field(foreign_key="jobs.id", ondelete="SET NULL")
     user_id: Optional[str] = sa.Field(foreign_key="users.id", ondelete="SET NULL")
     language: Optional[str] = sa.Field(default=None, description="Target language code, e.g. 'en'")
+    volume: Optional[int] = sa.Field(
+        default=None,
+        index=True,
+        description="Volume serial number when the artifact covers a single volume; "
+        "None means the artifact covers the whole novel",
+    )
     format: OutputFormat = sa.Field(
         sa_column=sa.Column(sa.Enum(OutputFormat, native_enum=False), nullable=False, index=True),
         description="The output format of the artifact",

--- a/lncrawl/migrations/versions/2026_07_16_00_00_00_artifact_volume_column.py
+++ b/lncrawl/migrations/versions/2026_07_16_00_00_00_artifact_volume_column.py
@@ -1,0 +1,32 @@
+"""Artifact volume column
+
+Revision ID: e5f6a7b8c9d0
+Revises: d4e5f6a7b8c9
+Create Date: 2026-07-16 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "e5f6a7b8c9d0"
+down_revision: Union[str, Sequence[str], None] = "d4e5f6a7b8c9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "artifacts",
+        sa.Column("volume", sa.Integer(), nullable=True),
+    )
+    op.create_index("ix_artifacts_volume", "artifacts", ["volume"])
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index("ix_artifacts_volume", table_name="artifacts")
+    op.drop_column("artifacts", "volume")

--- a/lncrawl/server/api/artifacts.py
+++ b/lncrawl/server/api/artifacts.py
@@ -24,6 +24,7 @@ def list_artifacts(
     novel_id: Optional[str] = Query(default=None),
     format: Optional[OutputFormat] = Query(default=None),
     language: Optional[LanguageCode] = Query(default=None),
+    volume: Optional[int] = Query(default=None),
 ) -> Paginated[Artifact]:
     return ctx.artifacts.list(
         limit=limit,
@@ -33,6 +34,7 @@ def list_artifacts(
         format=format,
         novel_id=novel_id,
         language=language,
+        volume=volume,
     )
 
 

--- a/lncrawl/server/api/jobs.py
+++ b/lncrawl/server/api/jobs.py
@@ -163,11 +163,15 @@ def make_artifacts(
     formats = list(set(body.formats) & ctx.tier.enabled_formats(user))
     if len(formats) == 0:
         raise ServerErrors.no_artifacts_to_create
+    if body.volume is not None:
+        # validate the volume exists for this novel (raises if not found)
+        ctx.volumes.find(body.novel_id, body.volume)
     return ctx.jobs.make_many_artifacts(
         user,
         body.novel_id,
         *formats,
         language=body.language,
+        volume=body.volume,
     )
 
 

--- a/lncrawl/server/api/novels.py
+++ b/lncrawl/server/api/novels.py
@@ -112,8 +112,9 @@ async def get_novel_chapters(
 async def get_novel_artifacts(
     novel_id: str = Path(),
     language: Optional[LanguageCode] = Query(default=None),
+    volume: Optional[int] = Query(default=None),
 ) -> List[Artifact]:
-    return ctx.artifacts.list_latest(novel_id, language)
+    return ctx.artifacts.list_latest(novel_id, language, volume)
 
 
 @router.get("/{novel_id}/recommended", summary="Gets recommended novels based on similarity")

--- a/lncrawl/server/models/job.py
+++ b/lncrawl/server/models/job.py
@@ -26,6 +26,11 @@ class MakeArtifactsRequest(BaseModel):
     novel_id: str = Field(description="The novel id")
     formats: List[OutputFormat] = Field(description="List of formats")
     language: Optional[LanguageCode] = Field(default=None, description="Target language code")
+    volume: Optional[int] = Field(
+        default=None,
+        description="Volume serial number to build a single-volume artifact; "
+        "omit to build the whole novel",
+    )
 
 
 class TranslateNovelsRequest(BaseModel):

--- a/lncrawl/services/artifacts.py
+++ b/lncrawl/services/artifacts.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from sqlmodel import and_, asc, col, desc, func, select
+import sqlmodel as sq
 
 from ..context import ctx
 from ..dao import Artifact, LanguageCode, OutputFormat, User, UserRole
@@ -24,7 +24,7 @@ class ArtifactService:
         volume: Optional[int] = None,
     ) -> Paginated[Artifact]:
         with ctx.db.session() as sess:
-            stmt = select(Artifact)
+            stmt = sq.select(Artifact)
 
             # Apply filters
             if novel_id:
@@ -41,9 +41,9 @@ class ArtifactService:
                 stmt = stmt.where(Artifact.volume == volume)
 
             # Apply sorting
-            stmt = stmt.order_by(desc(Artifact.updated_at))
+            stmt = stmt.order_by(sq.desc(Artifact.updated_at))
 
-            total = sess.exec(select(func.count()).select_from(Artifact)).one()
+            total = sess.exec(sq.select(sq.func.count()).select_from(Artifact)).one()
             items = sess.exec(stmt.offset(offset).limit(limit)).all()
 
             return Paginated(
@@ -75,7 +75,7 @@ class ArtifactService:
     def get_epub(self, depends_on_job_id: str) -> Artifact:
         with ctx.db.session() as sess:
             artifact = sess.exec(
-                select(Artifact).where(Artifact.job_id == depends_on_job_id)
+                sq.select(Artifact).where(Artifact.job_id == depends_on_job_id)
             ).first()
             if not artifact or not artifact.is_available:
                 raise ServerErrors.no_epub_file
@@ -84,36 +84,36 @@ class ArtifactService:
     def list_latest(self, novel_id: str, language: Optional[LanguageCode] = None) -> List[Artifact]:
         with ctx.db.session() as sess:
             subq = (
-                select(Artifact.format, func.max(Artifact.updated_at).label("max_updated_at"))
+                sq.select(Artifact.format, sq.func.max(Artifact.updated_at).label("max_updated_at"))
                 .where(
                     Artifact.novel_id == novel_id,
                     Artifact.language == language,
-                    col(Artifact.volume).is_(None),  # whole-novel artifacts only
+                    sq.col(Artifact.volume).is_(None),  # whole-novel artifacts only
                 )
                 .group_by(Artifact.format)
                 .subquery()
             )
             rows = sess.exec(
-                select(Artifact)
+                sq.select(Artifact)
                 .join(
                     subq,
-                    and_(
+                    sq.and_(
                         Artifact.format == subq.c.format,
                         Artifact.updated_at == subq.c.max_updated_at,
                     ),
                 )
-                .order_by(asc(Artifact.format))
+                .order_by(sq.asc(Artifact.format))
             ).all()
             return list(rows)
 
     def get_latest(self, novel_id: str, format: OutputFormat) -> Optional[Artifact]:
         with ctx.db.session() as sess:
             artifact = sess.exec(
-                select(Artifact)
+                sq.select(Artifact)
                 .where(Artifact.novel_id == novel_id)
                 .where(Artifact.format == format)
-                .where(col(Artifact.volume).is_(None))  # whole-novel artifacts only
-                .order_by(desc(Artifact.updated_at))
+                .where(sq.col(Artifact.volume).is_(None))  # whole-novel artifacts only
+                .order_by(sq.desc(Artifact.updated_at))
                 .limit(1)
             ).first()
             return artifact

--- a/lncrawl/services/artifacts.py
+++ b/lncrawl/services/artifacts.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from sqlmodel import and_, asc, desc, func, select, col
+from sqlmodel import and_, asc, col, desc, func, select
 
 from ..context import ctx
 from ..dao import Artifact, LanguageCode, OutputFormat, User, UserRole
@@ -112,7 +112,7 @@ class ArtifactService:
                 select(Artifact)
                 .where(Artifact.novel_id == novel_id)
                 .where(Artifact.format == format)
-                .where(Artifact.volume.is_(None))  # whole-novel artifacts only
+                .where(col(Artifact.volume).is_(None))  # whole-novel artifacts only
                 .order_by(desc(Artifact.updated_at))
                 .limit(1)
             ).first()

--- a/lncrawl/services/artifacts.py
+++ b/lncrawl/services/artifacts.py
@@ -81,14 +81,19 @@ class ArtifactService:
                 raise ServerErrors.no_epub_file
             return artifact
 
-    def list_latest(self, novel_id: str, language: Optional[LanguageCode] = None) -> List[Artifact]:
+    def list_latest(
+        self,
+        novel_id: str,
+        language: Optional[LanguageCode] = None,
+        volume: Optional[int] = None,
+    ) -> List[Artifact]:
         with ctx.db.session() as sess:
             subq = (
                 sq.select(Artifact.format, sq.func.max(Artifact.updated_at).label("max_updated_at"))
                 .where(
                     Artifact.novel_id == novel_id,
                     Artifact.language == language,
-                    sq.col(Artifact.volume).is_(None),  # whole-novel artifacts only
+                    self._volume_filter(volume),
                 )
                 .group_by(Artifact.format)
                 .subquery()
@@ -106,14 +111,26 @@ class ArtifactService:
             ).all()
             return list(rows)
 
-    def get_latest(self, novel_id: str, format: OutputFormat) -> Optional[Artifact]:
+    def get_latest(
+        self,
+        novel_id: str,
+        format: OutputFormat,
+        volume: Optional[int] = None,
+    ) -> Optional[Artifact]:
         with ctx.db.session() as sess:
             artifact = sess.exec(
                 sq.select(Artifact)
                 .where(Artifact.novel_id == novel_id)
                 .where(Artifact.format == format)
-                .where(sq.col(Artifact.volume).is_(None))  # whole-novel artifacts only
+                .where(self._volume_filter(volume))
                 .order_by(sq.desc(Artifact.updated_at))
                 .limit(1)
             ).first()
             return artifact
+
+    @staticmethod
+    def _volume_filter(volume: Optional[int]):
+        """Match a specific volume when given, else whole-novel artifacts only."""
+        if volume is not None:
+            return Artifact.volume == volume
+        return sq.col(Artifact.volume).is_(None)

--- a/lncrawl/services/artifacts.py
+++ b/lncrawl/services/artifacts.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from sqlmodel import and_, asc, desc, func, select
+from sqlmodel import and_, asc, desc, func, select, col
 
 from ..context import ctx
 from ..dao import Artifact, LanguageCode, OutputFormat, User, UserRole
@@ -88,7 +88,7 @@ class ArtifactService:
                 .where(
                     Artifact.novel_id == novel_id,
                     Artifact.language == language,
-                    Artifact.volume == None,  # noqa: E711 -- whole-novel artifacts only
+                    col(Artifact.volume).is_(None),  # whole-novel artifacts only
                 )
                 .group_by(Artifact.format)
                 .subquery()

--- a/lncrawl/services/artifacts.py
+++ b/lncrawl/services/artifacts.py
@@ -107,6 +107,13 @@ class ArtifactService:
                         Artifact.updated_at == subq.c.max_updated_at,
                     ),
                 )
+                # re-apply the same filters on the outer row so a different
+                # novel/language/volume sharing (format, updated_at) can't leak in
+                .where(
+                    Artifact.novel_id == novel_id,
+                    Artifact.language == language,
+                    self._volume_filter(volume),
+                )
                 .order_by(sq.asc(Artifact.format))
             ).all()
             return list(rows)

--- a/lncrawl/services/artifacts.py
+++ b/lncrawl/services/artifacts.py
@@ -21,6 +21,7 @@ class ArtifactService:
         novel_id: Optional[str] = None,
         format: Optional[OutputFormat] = None,
         language: Optional[LanguageCode] = None,
+        volume: Optional[int] = None,
     ) -> Paginated[Artifact]:
         with ctx.db.session() as sess:
             stmt = select(Artifact)
@@ -36,6 +37,8 @@ class ArtifactService:
                 stmt = stmt.where(Artifact.format == format)
             if language:
                 stmt = stmt.where(Artifact.language == language)
+            if volume is not None:
+                stmt = stmt.where(Artifact.volume == volume)
 
             # Apply sorting
             stmt = stmt.order_by(desc(Artifact.updated_at))
@@ -85,6 +88,7 @@ class ArtifactService:
                 .where(
                     Artifact.novel_id == novel_id,
                     Artifact.language == language,
+                    Artifact.volume == None,  # noqa: E711 -- whole-novel artifacts only
                 )
                 .group_by(Artifact.format)
                 .subquery()
@@ -108,6 +112,7 @@ class ArtifactService:
                 select(Artifact)
                 .where(Artifact.novel_id == novel_id)
                 .where(Artifact.format == format)
+                .where(Artifact.volume == None)  # noqa: E711 -- whole-novel artifacts only
                 .order_by(desc(Artifact.updated_at))
                 .limit(1)
             ).first()

--- a/lncrawl/services/artifacts.py
+++ b/lncrawl/services/artifacts.py
@@ -112,7 +112,7 @@ class ArtifactService:
                 select(Artifact)
                 .where(Artifact.novel_id == novel_id)
                 .where(Artifact.format == format)
-                .where(Artifact.volume == None)  # noqa: E711 -- whole-novel artifacts only
+                .where(Artifact.volume.is_(None))  # whole-novel artifacts only
                 .order_by(desc(Artifact.updated_at))
                 .limit(1)
             ).first()

--- a/lncrawl/services/binder/epub.py
+++ b/lncrawl/services/binder/epub.py
@@ -202,7 +202,10 @@ def make_epub(working_dir: Path, artifact: Artifact, signal=Event(), **kwargs) -
     # add volumes and chapters pages
     if signal.is_set():
         raise AbortedException()
-    for volume in ctx.volumes.list(artifact.novel_id, language):
+    volumes = ctx.volumes.list(artifact.novel_id, language)
+    if artifact.volume is not None:
+        volumes = [v for v in volumes if v.serial == artifact.volume]
+    for volume in volumes:
         if signal.is_set():
             raise AbortedException()
 

--- a/lncrawl/services/binder/epub.py
+++ b/lncrawl/services/binder/epub.py
@@ -202,9 +202,10 @@ def make_epub(working_dir: Path, artifact: Artifact, signal=Event(), **kwargs) -
     # add volumes and chapters pages
     if signal.is_set():
         raise AbortedException()
-    volumes = ctx.volumes.list(artifact.novel_id, language)
     if artifact.volume is not None:
-        volumes = [v for v in volumes if v.serial == artifact.volume]
+        volumes = [ctx.volumes.find_translated(artifact.novel_id, artifact.volume, language)]
+    else:
+        volumes = ctx.volumes.list(artifact.novel_id, language)
     for volume in volumes:
         if signal.is_set():
             raise AbortedException()

--- a/lncrawl/services/binder/json.py
+++ b/lncrawl/services/binder/json.py
@@ -24,7 +24,10 @@ def make_json(working_dir: Path, artifact: Artifact, signal=Event(), **kwargs) -
     with zipfile.ZipFile(tmp_file, "w", zipfile.ZIP_DEFLATED) as zipf:
         if signal.is_set():
             raise AbortedException()
-        for volume in ctx.volumes.list(artifact.novel_id, language=language):
+        volumes = ctx.volumes.list(artifact.novel_id, language=language)
+        if artifact.volume is not None:
+            volumes = [v for v in volumes if v.serial == artifact.volume]
+        for volume in volumes:
             vol_data = volume.model_dump()
             vol_data["chapters"] = []
             novel_data["volumes"].append(vol_data)

--- a/lncrawl/services/binder/json.py
+++ b/lncrawl/services/binder/json.py
@@ -24,9 +24,10 @@ def make_json(working_dir: Path, artifact: Artifact, signal=Event(), **kwargs) -
     with zipfile.ZipFile(tmp_file, "w", zipfile.ZIP_DEFLATED) as zipf:
         if signal.is_set():
             raise AbortedException()
-        volumes = ctx.volumes.list(artifact.novel_id, language=language)
         if artifact.volume is not None:
-            volumes = [v for v in volumes if v.serial == artifact.volume]
+            volumes = [ctx.volumes.find_translated(artifact.novel_id, artifact.volume, language)]
+        else:
+            volumes = ctx.volumes.list(artifact.novel_id, language=language)
         for volume in volumes:
             vol_data = volume.model_dump()
             vol_data["chapters"] = []

--- a/lncrawl/services/binder/service.py
+++ b/lncrawl/services/binder/service.py
@@ -67,6 +67,7 @@ class BinderService:
         user_id: Optional[str] = None,
         epub: Optional[Artifact] = None,
         language: Optional[LanguageCode] = None,
+        volume: Optional[int] = None,
         signal=Event(),
     ) -> Artifact:
         make = archive_maker[format]
@@ -74,6 +75,8 @@ class BinderService:
             raise ServerErrors.format_not_available
 
         file_name = safe_filename(novel_title).title()
+        if volume is not None:
+            file_name += f".Vol_{volume:03}"
         if language:
             file_name += f".{language}"
         file_name += f".{format}"
@@ -86,6 +89,7 @@ class BinderService:
             job_id=job_id,
             format=format,
             language=language,
+            volume=volume,
             file_name=file_name,
         )
 

--- a/lncrawl/services/binder/text.py
+++ b/lncrawl/services/binder/text.py
@@ -21,7 +21,10 @@ def make_text(working_dir: Path, artifact: Artifact, signal=Event(), **kwargs) -
     with zipfile.ZipFile(tmp_file, "w", zipfile.ZIP_DEFLATED) as zipf:
         if signal.is_set():
             raise AbortedException()
-        for volume in ctx.volumes.list(artifact.novel_id, language=language):
+        volumes = ctx.volumes.list(artifact.novel_id, language=language)
+        if artifact.volume is not None:
+            volumes = [v for v in volumes if v.serial == artifact.volume]
+        for volume in volumes:
             if signal.is_set():
                 raise AbortedException()
             for chapter in ctx.chapters.list(volume_id=volume.id, language=language):

--- a/lncrawl/services/binder/text.py
+++ b/lncrawl/services/binder/text.py
@@ -21,9 +21,10 @@ def make_text(working_dir: Path, artifact: Artifact, signal=Event(), **kwargs) -
     with zipfile.ZipFile(tmp_file, "w", zipfile.ZIP_DEFLATED) as zipf:
         if signal.is_set():
             raise AbortedException()
-        volumes = ctx.volumes.list(artifact.novel_id, language=language)
         if artifact.volume is not None:
-            volumes = [v for v in volumes if v.serial == artifact.volume]
+            volumes = [ctx.volumes.find_translated(artifact.novel_id, artifact.volume, language)]
+        else:
+            volumes = ctx.volumes.list(artifact.novel_id, language=language)
         for volume in volumes:
             if signal.is_set():
                 raise AbortedException()

--- a/lncrawl/services/jobs/service.py
+++ b/lncrawl/services/jobs/service.py
@@ -547,6 +547,7 @@ class JobService:
         parent_id: Optional[str] = None,
         depends_on: Optional[str] = None,
         language: Optional[LanguageCode] = None,
+        volume: Optional[int] = None,
         **data: Any,
     ) -> Job:
         data.update(
@@ -554,6 +555,7 @@ class JobService:
                 "novel_id": novel_id,
                 "format": format,
                 "language": language,
+                "volume": volume,
             }
         )
         if not data.get("novel_title"):
@@ -579,6 +581,7 @@ class JobService:
         parent_id: Optional[str] = None,
         depends_on: Optional[str] = None,
         language: Optional[LanguageCode] = None,
+        volume: Optional[int] = None,
         **data: Any,
     ) -> Job:
         data.update(
@@ -586,6 +589,7 @@ class JobService:
                 "novel_id": novel_id,
                 "formats": formats,
                 "language": language,
+                "volume": volume,
             }
         )
         if not data.get("novel_title"):

--- a/lncrawl/services/scheduler/handlers/artifact.py
+++ b/lncrawl/services/scheduler/handlers/artifact.py
@@ -20,6 +20,7 @@ class ArtifactHandler(BaseHandler):
             raise HandlerException("No output format")
 
         language = self.job.extra.get("language")
+        volume = self.job.extra.get("volume")
 
         if format not in _ALL_OUTPUT_FORMATS:
             raise HandlerException(f"Invalid format: {format}")
@@ -48,6 +49,7 @@ class ArtifactHandler(BaseHandler):
             user_id=self.user.id,
             epub=epub,
             language=language,
+            volume=volume,
             signal=self.signal,
         )
         if not artifact.is_available:

--- a/lncrawl/services/scheduler/handlers/artifact_batch.py
+++ b/lncrawl/services/scheduler/handlers/artifact_batch.py
@@ -57,5 +57,6 @@ class ArtifactBatchHandler(BatchHandler):
             parent_id=self.job.id,
             depends_on=epub_job_id,
             language=self.job.extra.get("language"),
+            volume=self.job.extra.get("volume"),
             novel_title=self.job.extra.get("novel_title"),
         )

--- a/lncrawl/services/volumes.py
+++ b/lncrawl/services/volumes.py
@@ -80,6 +80,16 @@ class VolumeService:
                 raise ServerErrors.no_such_volume
             return volume
 
+    def find_translated(
+        self,
+        novel_id: str,
+        serial: int,
+        language: Optional[LanguageCode] = None,
+    ) -> Volume:
+        volume = self.find(novel_id, serial)
+        self._put_translations([volume], language)
+        return volume
+
     def get_volume_translation(self, volume: Volume, language: LanguageCode):
         with ctx.db.session() as sess:
             return sess.exec(


### PR DESCRIPTION
## What does this PR do?

Adds the ability to generate an e-book artifact for a single volume of a novel, instead of always binding the whole novel.

## Type of change

- [ ] Bug fix
- [ ] New source
- [x] Feature / enhancement
- [ ] Docs / chore

## Details

**Motivation:** long novels can be split into many volumes; users often want just one volume as a standalone e-book rather than the entire series in one file.

**How it works:** `POST /api/jobs/create/make-artifacts` gains an optional `volume` (volume serial number). When set, the request builds an artifact covering only that volume; when omitted, behavior is unchanged (whole novel). The value flows through the job factory → `ArtifactBatchHandler`/`ArtifactHandler` → `BinderService.make_artifact` → the epub/json/text makers, which filter their volume iteration to the requested serial. Calibre-derived formats (mobi/pdf/…) inherit the single-volume EPUB automatically, so no separate handling is needed there.

**Persistence & API:**
- New nullable, indexed `volume` column on the `Artifact` model, with an Alembic migration (`artifact_volume_column`). `verify` passes.
- The output file name reflects the volume (e.g. `Novel.Vol_003.epub`).
- `GET /api/artifacts` gains a `volume` query filter.
- The endpoint validates the volume exists for the novel via `ctx.volumes.find` before enqueuing.

**Trade-off / design choice:** `list_latest`/`get_latest` are restricted to whole-novel artifacts (`volume IS NULL`), so the novel detail page and download emails keep showing full-novel downloads and don't accidentally surface a single-volume file as "the latest EPUB". Single-volume artifacts are still discoverable through the `volume` filter on the list endpoint.

Note: the web UI lives in the separate `lncrawl-web` repo — this PR is engine/API only.

## Checklist

- [x] `make lint` passes with no errors
- [x] Tested manually — exercised the binder end-to-end against a fixture novel (2 volumes × 2 chapters): whole-novel EPUB = 4 chapters; `volume=1` EPUB = 2 chapters named `...Vol_001.epub`; `volume=2` JSON scoped to `002/`; `list_latest` returns only the whole-novel artifact; `list(volume=1)` returns only the volume-1 artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MXSMmQvnqim9tecusAhvtY)_