### PR TITLE
Send auto-invite as a threaded reply to the incoming email

### DIFF
--- a/lncrawl/services/mail.py
+++ b/lncrawl/services/mail.py
@@ -76,7 +76,15 @@ class MailService:
             server.close()
             raise ServerErrors.smtp_server_login_fail from e
 
-    def send(self, email: str, subject: str, html_body: str):
+    def send(
+        self,
+        email: str,
+        subject: str,
+        html_body: str,
+        *,
+        in_reply_to: str | None = None,
+        references: str | None = None,
+    ):
         if not ctx.config.mail.smtp_enabled:
             logger.debug(f"SMTP disabled, skipping email to {email!r}")
             return
@@ -91,6 +99,11 @@ class MailService:
         msg["From"] = self.sender
         msg["To"] = email
 
+        if in_reply_to:
+            msg["In-Reply-To"] = in_reply_to
+            chain = f"{references} {in_reply_to}".strip() if references else in_reply_to
+            msg["References"] = chain
+
         try:
             with self._smtp_lock:
                 self.server.sendmail(msg["From"], [msg["To"]], msg.as_string())
@@ -99,10 +112,30 @@ class MailService:
         except Exception as e:
             raise ServerErrors.email_send_failure from e
 
-    def send_invite(self, email: str, inviter_name: str, link: str):
-        subject = "Lightnovel Crawler Invitation"
+    def send_invite(
+        self,
+        email: str,
+        inviter_name: str,
+        link: str,
+        *,
+        reply_subject: str | None = None,
+        in_reply_to: str | None = None,
+        references: str | None = None,
+    ):
+        if reply_subject:
+            subject = reply_subject.strip()
+            if not subject.lower().startswith("re:"):
+                subject = f"Re: {subject}"
+        else:
+            subject = "Lightnovel Crawler Invitation"
         body = emails.invite_template().render(inviter_name=inviter_name, link=link)
-        self.send(email, subject, body)
+        self.send(
+            email,
+            subject,
+            body,
+            in_reply_to=in_reply_to,
+            references=references,
+        )
 
     def send_otp(self, email: str, otp: str):
         subject = f"OTP ({otp})"
@@ -229,7 +262,15 @@ class MailService:
             return
         try:
             admin = ctx.users.get_admin()
-            ctx.users.send_invite_email(admin, sender)
+            message_id = (msg.obj.get("Message-ID") or "").strip() or None
+            references = (msg.obj.get("References") or "").strip() or None
+            ctx.users.send_invite_email(
+                admin,
+                sender,
+                reply_subject=msg.subject or None,
+                in_reply_to=message_id,
+                references=references,
+            )
             mb.flag([msg.uid], [MailMessageFlags.SEEN, MailMessageFlags.ANSWERED], True)
             logger.info(f"Sent invite to {sender}")
         except Exception as e:

--- a/lncrawl/services/users.py
+++ b/lncrawl/services/users.py
@@ -337,9 +337,9 @@ class UserService:
         inviter: User,
         recipient_email: str,
         *,
-        reply_subject: str | None = None,
-        in_reply_to: str | None = None,
-        references: str | None = None,
+        reply_subject: Optional[str] = None,
+        in_reply_to: Optional[str] = None,
+        references: Optional[str] = None,
     ) -> None:
         token = self.get_signup_token(inviter)
         base_url = ctx.config.server.base_url

--- a/lncrawl/services/users.py
+++ b/lncrawl/services/users.py
@@ -332,13 +332,28 @@ class UserService:
             stmt = sq.select(sq.func.count()).where(User.email == email)
             return sess.exec(stmt).one() != 0
 
-    def send_invite_email(self, inviter: User, recipient_email: str) -> None:
+    def send_invite_email(
+        self,
+        inviter: User,
+        recipient_email: str,
+        *,
+        reply_subject: str | None = None,
+        in_reply_to: str | None = None,
+        references: str | None = None,
+    ) -> None:
         token = self.get_signup_token(inviter)
         base_url = ctx.config.server.base_url
         search = urlencode({"referrer": token, "email": recipient_email})
         link = f"{base_url}/signup?{search}"
         inviter_name = inviter.name or inviter.email
-        ctx.mail.send_invite(recipient_email, inviter_name, link)
+        ctx.mail.send_invite(
+            recipient_email,
+            inviter_name,
+            link,
+            reply_subject=reply_subject,
+            in_reply_to=in_reply_to,
+            references=references,
+        )
 
     def get_signup_token(self, user: User) -> str:
         day = 24 * 3600 * 1000


### PR DESCRIPTION
Reply within the sender's own thread instead of sending a fresh email,
which is far more likely to be filtered as spam.

- Set In-Reply-To/References from the incoming message's headers
- Use "Re: <subject>" for the reply subject
- Thread the headers through send_invite_email/send_invite/send; the
  admin-initiated invite path is unchanged