### PR TITLE
Fix bugs in freewebnovel, novelfire, and novelhall crawlers

### DIFF
--- a/sources/en/f/freewebnovel.py
+++ b/sources/en/f/freewebnovel.py
@@ -38,26 +38,35 @@ class FreewebnovelCrawler(FreewebnovelTemplate):
         clean_url = novel.url.split("?")[0]
         total_page, page_size = self._get_chapter_pagination(tag)
         futures = [
-            self.taskman.submit_task(
-                self.scraper.submit_form,
-                url=clean_url
-                + "?"
-                + urlencode(
-                    {
-                        "ajax": "chapters",
-                        "page": page,
-                        "pageSize": page_size,
-                    }
+            (
+                page,
+                self.taskman.submit_task(
+                    self.scraper.submit_form,
+                    url=clean_url
+                    + "?"
+                    + urlencode(
+                        {
+                            "ajax": "chapters",
+                            "page": page,
+                            "pageSize": page_size,
+                        }
+                    ),
                 ),
             )
             for page in range(1, total_page + 1)
         ]
-        for resp in self.taskman.resolve(
-            futures,
-            desc="Index",
-            unit="page",
-            fail_fast=True,
-        ):
+
+        list(
+            self.taskman.resolve(
+                [f for _, f in futures],
+                desc="Index",
+                unit="page",
+                fail_fast=True,
+            )
+        )
+
+        for page, future in sorted(futures, key=lambda x: x[0]):
+            resp = future.result()
             assert resp, "failed to fetch chapter list"
             data = resp.json()
             assert "html" in data, "invalid chapter list result"

--- a/sources/en/n/novelfire.py
+++ b/sources/en/n/novelfire.py
@@ -1,5 +1,6 @@
 import logging
 import re
+import time
 
 from lncrawl.core import Chapter, LegacyCrawler, Volume
 from lncrawl.core.models import SearchResult
@@ -15,7 +16,7 @@ class NovelFireCrawler(LegacyCrawler):
     has_mtl = False
     has_manga = False
     can_search = True
-    request_rate_limit = 3
+    request_rate_limit = 1
 
     def read_novel_info(self) -> None:
         soup = self.get_soup(self.novel_url)
@@ -30,6 +31,7 @@ class NovelFireCrawler(LegacyCrawler):
         vol_url = self.novel_url + "/chapters"
 
         while vol_url:
+            time.sleep(0.5)
             soup = self.get_soup(self.absolute_url(vol_url))
 
             chapters = soup.select("ul.chapter-list li a")
@@ -56,8 +58,10 @@ class NovelFireCrawler(LegacyCrawler):
 
     def download_chapter_body(self, chapter) -> str:
         soup = self.get_soup(chapter["url"])
-        contents = soup.select_one("div#content")
-        if not contents:
+        contents = soup.select_one(
+            "div#content, div.chapter-content, div.content, div.cha-content, .cha-words"
+        )
+        if not contents or not contents.text.strip():
             return ""
 
         # 1. Look through the very top elements inside the content container

--- a/sources/en/n/novelhall.py
+++ b/sources/en/n/novelhall.py
@@ -14,6 +14,7 @@ class NovelHallCrawler(LegacyCrawler):
 
     has_manga = False
     has_mtl = True
+    request_rate_limit = 1
 
     def search_novel(self, query: str):
         url = f"/index.php?s=so&module=book&keyword={quote_plus(query.lower())}"
@@ -72,7 +73,9 @@ class NovelHallCrawler(LegacyCrawler):
                 blue.extract()
             self.novel_synopsis = self.cleaner.extract_contents(synopsis)
 
-        for a in soup.select("#morelist.book-catalog ul li a[href]"):
+        for a in soup.select(
+            "#morelist.book-catalog ul li a[href], #morelist ul li a[href], .book-catalog ul li a[href]"
+        ):
             chap_id = len(self.chapters) + 1
             vol_id = len(self.chapters) // 100 + 1
             if len(self.volumes) < vol_id:
@@ -88,5 +91,9 @@ class NovelHallCrawler(LegacyCrawler):
 
     def download_chapter_body(self, chapter):
         soup = self.get_soup(chapter["url"])
-        contents = soup.select_one("div#htmlContent.entry-content")
+        contents = soup.select_one(
+            "div#htmlContent.entry-content, div#htmlContent, div.entry-content"
+        )
+        if not contents:
+            return ""
         return self.cleaner.extract_contents(contents)


### PR DESCRIPTION
## What does this PR do?

Fixes multiple upstream bugs regarding chapter ordering, rate limiting, and extraction failures for Freewebnovel, Novelfire, and Novelhall.

## Type of change

- [x] Bug fix
- [ ] New source
- [ ] Feature / enhancement
- [ ] Docs / chore

## Details

**Freewebnovel (Fixes #3146)** 
- **Bug:** Chapters fetched via pagination were being appended out of order based on which network request finished first (`as_completed`), causing random jumps in the chapter list.
- **Fix:** Refactored `select_chapter_tags` to pair futures with their page number, wait for all requests to complete, and yield them in strictly sequential page order.

**Novelfire (Fixes #3144, #3135)**
- **Bug:** Crawler frequently hit `429 Too Many Requests` during pagination, and chapter bodies extracted as empty ("No Content Available") due to rigid selectors.
- **Fix:** Lowered `request_rate_limit` to 1 and added a small explicit delay (`time.sleep(0.5)`) between pagination requests. Replaced the strict `div#content` selector with resilient fallback selectors (`div#content`, `div.chapter-content`, `div.content`, `div.cha-content`, `.cha-words`).
- **Tested URL:** `https://novelfire.net/book/monsters-wag-their-tails-only-at-me`

**Novelhall (Fixes #3155)**
- **Bug:** Outdated selectors caused chapter lists to fail to parse and download processes to crash with `NoneType` errors.
- **Fix:** Included robust fallback selectors for both chapter indexing (`#morelist.book-catalog`, `#morelist`, `.book-catalog`) and body extraction (`div#htmlContent.entry-content`, `div#htmlContent`, `div.entry-content`). Added explicit safety checks to gracefully handle missing content blocks. Lowered request rate limit to 1.
- **Tested URL:** `https://www.novelhall.com/2022baby-comes-mysterious-billionaire-s-cute-wife-17484/`

## Checklist

- [x] `make lint` passes with no errors
- [x] Tested manually (crawl command or server)