### PR TITLE
Keep multiline synopsis when exporting to Epub

### DIFF
--- a/lncrawl/services/binder/epub.py
+++ b/lncrawl/services/binder/epub.py
@@ -51,7 +51,7 @@ def build_intro(novel: Novel) -> epub.EpubHtml:
         <h1>{novel.title}</h1>
         <h3>{novel.authors}</h3>
         <div class="synopsis">
-            {novel.synopsis}
+            {"".join(f"<p>{line}</p>" for line in (novel.synopsis or "").splitlines())}
         </div>
         <div class="footer">
             <b>Source:</b> <a href="{novel.url}">{novel.url}</a>


### PR DESCRIPTION
## What does this PR do?

Ensures multiline synopsis is maintained when exporting to epub

## Type of change

- [ ] Bug fix
- [ ] New source
- [x] Feature / enhancement
- [ ] Docs / chore

## Details

https://novelfire.net/book/ending-maker

## Checklist

- [x] `make lint` passes with no errors
- [x] Tested manually (crawl command or server)
