### PR TITLE
fix: add tini to reap zombie browser processes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ ENV LNCRAWL_DATA_PATH=/data \
 
 # Firefox, from Mozilla
 RUN apt-get update -yq && \
-    apt-get install -yq --no-install-recommends ca-certificates wget xz-utils \
+    apt-get install -yq --no-install-recommends ca-certificates wget xz-utils tini \
     libgtk-3-0 libdbus-glib-1-2 libasound2t64 libx11-xcb1 libxtst6 libxt6 libpci3 \
     fonts-liberation fonts-dejavu && \
     case "$(dpkg --print-architecture)" in \
@@ -57,4 +57,4 @@ COPY pyproject.toml uv.lock ./
 COPY lncrawl ./lncrawl
 COPY sources ./sources
 
-ENTRYPOINT ["/app/.venv/bin/python", "-m", "lncrawl"]
+ENTRYPOINT ["/usr/bin/tini", "--", "/app/.venv/bin/python", "-m", "lncrawl"]


### PR DESCRIPTION
## What does this PR do?

Adds tini as PID 1 in the Docker image so orphaned Firefox helper processes get reaped instead of accumulating as zombies.

## Type of change

- [x] Bug fix
- [ ] New source
- [ ] Feature / enhancement
- [ ] Docs / chore

## Details

The runtime image sets `ENTRYPOINT ["/app/.venv/bin/python", "-m", "lncrawl"]`, so Python runs as PID 1. Python does not reap orphaned child processes, and it installs no default SIGTERM handler, both of which matter only at PID 1.

Firefox is launched for challenge solving and spawns a full set of Gecko helpers per launch (`crashhelper`, `forkserver`, `Socket Process`, `RDD Process`, `Web Content`, `Isolated Web Content`, `WebExtensions`, `Utility Process`, `Privileged Content`). Any that get reparented to PID 1 stay as zombies until the container restarts. On my instance that is roughly 13 defunct processes per browser launch, all with the container's PID 1 as parent:

```
1097588 3512378 Z    crashhelper
1097645 3512378 Z    forkserver
1097648 3512378 Z    Socket Process
1097670 3512378 Z    WebExtensions
1097676 3512378 Z    RDD Process
1097722 3512378 Z    Web Content
```

They only clear on restart, and left long enough this will exhaust the pid limit and the container can no longer fork at all.

Second symptom from the same cause: `docker stop` currently waits the full 10 second timeout and then SIGKILLs, because SIGTERM to PID 1 with no handler is ignored.

Changes:
- install `tini` in the runtime stage (already in trixie, no new source needed)
- `ENTRYPOINT ["/usr/bin/tini", "--", "/app/.venv/bin/python", "-m", "lncrawl"]`

There is no `CMD`, so appended args like `-ll server` still pass through unchanged and the documented `docker run` command is unaffected. This is the approach `docker run --init` uses; tini is what ships as `docker-init`.

## Checklist

- [ ] `make lint` passes with no errors
- [x] Tested manually (crawl command or server)